### PR TITLE
Updated gulp tasks to live-reload on change and fix broken pug paths

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,21 +4,27 @@ var dest       = require('gulp-dest');
 var fs         = require('fs');
 var gulp       = require('gulp');
 var gulpPug    = require('gulp-pug');
-var liveServer = require('live-server');
+// var liveServer = require('live-server');
 var path       = require('path');
 var rename     = require('gulp-rename');
 var sass       = require('gulp-sass');
 var uglify     = require('gulp-uglify');
+var browserSync = require( 'browser-sync'),
+		reload      = browserSync.reload;
  
 //** FIX-ME **  auto-refresh in the browser does not function
 // Set root directory that's being server. If left blank, 
 // defaults to wherever 'gulp' command was issued.           
 // comma-separated string for paths to ignore - Does not work for some reason.
-var liveServerParams = {   
-	root: './build/html/', 
-	ignore: './build/html/layouts', 
-    wait: 200,
-};
+
+// ** REVIEW** Replaced with browser-sync to live reload when pug is updated and inject css
+// changes directly into the browser.
+// var liveServerParams = {   
+// 	root: './build/html/', 
+// 	ignore: './build/html/layouts', 
+//     wait: 200,
+// };
+
 
 var files = fs.readdirSync('src/pug/');
 
@@ -45,7 +51,8 @@ gulp.task('javascript', function(){
         .pipe(uglify())
         .on('error', swallowError)
         .pipe(rename({suffix: '.min'}))
-        .pipe(gulp.dest('./build/html/js/'));
+        .pipe(gulp.dest('./build/html/js/'))
+        .pipe(reload({stream:true}));
 });
 
 gulp.task('sass', function(){
@@ -55,20 +62,32 @@ gulp.task('sass', function(){
         .pipe(gulp.dest('./build/html/css/'))
         .pipe(cleancss())
         .pipe(rename({suffix: '.min'}))
-        .pipe(gulp.dest('./build/html/css/'));
+        .pipe(gulp.dest('./build/html/css/'))
+        .pipe(reload({stream:true}));
 });
 
 gulp.task('static', function() {
     return gulp.src('./src/img/**/*')
-        .pipe(gulp.dest('./build/html/img/'));
+        .pipe(gulp.dest('./build/html/img/'))
+        .pipe(reload({stream:true}));
 });
 
-gulp.task('default', ['fonts', 'pug', 'javascript', 'sass', 'static'], function () {
+gulp.task('watch', ['fonts', 'pug', 'javascript', 'sass', 'static'], function () {
     gulp.watch('./src/pug/**/*.pug', ['pug']);
     gulp.watch('./src/js/**/*.js', ['javascript']);
     gulp.watch('./src/scss/*.scss', ['sass']);
     gulp.watch('./src/img/**/*', ['static']);
-    liveServer.start(liveServerParams); // As replacement for using the gulp.task('live-server')
+		// ** REVIEW** Replaced with browserSync in the 'default task'
+    // liveServer.start(liveServerParams); // As replacement for using the gulp.task('live-server')
+    gulp.watch('./build/html/**/*.html', reload );
+});
+
+// Run the watch task(s) first, then run the server.
+// Serve files to browser
+gulp.task('default', ['watch'], function() {
+	browserSync({
+		server: { baseDir: './build/html/' }
+	})
 });
 
 function swallowError(error){

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   },
   "homepage": "https://github.com/wandrewkeech/gulp-pugitude#readme",
   "devDependencies": {
+    "browser-sync": "^2.18.12",
     "vanilla-framework": "^1.1.11"
   }
 }

--- a/src/pug/about/about.pug
+++ b/src/pug/about/about.pug
@@ -1,4 +1,5 @@
-extends layouts/main.pug
+//- **REVIEW** Fixed the path to source the main.pug from the parent dir.
+extends ../layouts/main.pug
 
 block title
     title Up Here in the Title Bar We Can Put Whatever We Want, Per-Page

--- a/src/pug/galleries/gallery1.pug
+++ b/src/pug/galleries/gallery1.pug
@@ -1,4 +1,5 @@
-extends layouts/main.pug
+//- **REVIEW** Fixed the path to source the main.pug from the parent dir.
+extends ../layouts/main.pug
 
 block title
     title this is a gallery title, substituting for the Default 


### PR DESCRIPTION
Hi Andy! 
I found your repo while searching for a Pug Static Site-Generator. Noticed your comments about the site not reloading manually when pug changes are saved and since I had just fixed this with another project, I thought I would share my solution with you. 
I replaced your live-server package with browser-sync and updated the tasks so that when pug/sass/js are changed, gulp will re-run the tasks like you had set up but will now re-load the browser for you. I seperated the 'watch' task and 'default' task to make sure the watcher runs first and then it runs the server when you run 'default.' 

Also, I was getting an error with your 'extends' paths in pug so I fixed that link. 

I left your original code in the gulpfile and just commented it out so that you could easily see the changes. 

If this isn't the kind of solution you were looking for, feel free to disregard my pull request :) 

Have a great day! 
-Yisrael